### PR TITLE
fix: getHeaderToken throws on webm token images

### DIFF
--- a/src/model/message/test.js
+++ b/src/model/message/test.js
@@ -92,7 +92,7 @@ export class OldWorldTestMessageModel extends WarhammerTestMessageModel
 
       if (foundry.helpers.media.VideoHelper.hasVideoExtension(path))
       {
-        path = await game.video.createThumbnail(path, { width: 50, height: 50 }).then(img => chatOptions.flags.img = img)
+        path = await game.video.createThumbnail(path, { width: 50, height: 50 });
       }
 
       return path;


### PR DESCRIPTION
When player had token with webm animated image the test dialogues do no render.

> createThumbnail() resolves to the thumbnail data URL directly; the stray .then(img => chatOptions.flags.img = img) referenced an undefined chatOptions variable, throwing a ReferenceError whenever a token used a .webm texture.

<img width="608" height="104" alt="image" src="https://github.com/user-attachments/assets/6c26bf98-11f0-4bb7-95f5-c98405044e00" />
